### PR TITLE
Update build-on-label.yml

### DIFF
--- a/.github/workflows/build-on-label.yml
+++ b/.github/workflows/build-on-label.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Upload APK Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
GitHub deprecated actions/upload-artifact@v3, so need to update your workflow to use the new version: actions/upload-artifact@v4.